### PR TITLE
ci(workflow): 修复 Linux 平台自动化构建

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,30 +34,35 @@ jobs:
           name: NamePicker-Windows-x64
           path: |
             namepicker\build\windows\x64\runner\Release
-  # build_linux:
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - name: Clone repository
-  #       uses: actions/checkout@v4
+  build_linux:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v4
 
-  #     - name: Set up Flutter
-  #       uses: subosito/flutter-action@v2
-  #       with:
-  #         channel: stable
+      - name: Set up Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          channel: stable
 
-  #     - name: Init flutter env
-  #       run: |
-  #         cd namepicker
-  #         flutter pub get
+      - name: Install Linux dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y clang cmake ninja-build pkg-config libgtk-3-dev
 
-  #     - name: Build linux app
-  #       run: |
-  #         cd namepicker
-  #         flutter build linux
+      - name: Init flutter env
+        run: |
+          cd namepicker
+          flutter pub get
 
-  #     - name: Upload linux artifact
-  #       uses: actions/upload-artifact@v4
-  #       with:
-  #         name: NamePicker-Linux-x64
-  #         path: |
-  #           namepicker\build\linux\x64\runner\Release
+      - name: Build linux app
+        run: |
+          cd namepicker
+          flutter build linux
+
+      - name: Upload linux artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: NamePicker-Linux-x64
+          path: |
+            namepicker/build/linux/x64/release/bundle


### PR DESCRIPTION
**变更摘要**
- 修复 GitHub Actions 的 Linux 桌面构建失败（缺少 `gtk+-3.0`）。
- 在 Linux 构建 Job 中新增依赖安装步骤，确保 `pkg-config` 能找到 `gtk+-3.0`。
- 修正 Linux 产物上传路径为 Flutter 的标准可分发目录。

**问题背景**
- 构建报错：`CMake Error ... The following required packages were not found: gtk+-3.0`，由 `flutter/CMakeLists.txt:25` 的 `pkg_check_modules(GTK3 REQUIRED gtk+-3.0)` 触发。
- Ubuntu 运行器默认未安装 `libgtk-3-dev`，`pkg-config` 无法解析 `gtk+-3.0`。
- 原工作流中的 Linux 产物路径使用了 Windows 风格反斜杠且指向了非分发目录，导致上传不正确。

**修改内容**
- 在 `.github/workflows/build.yml` 的 Linux Job 中新增依赖安装：
  - 安装 `clang`、`cmake`、`ninja-build`、`pkg-config`、`libgtk-3-dev`，以满足 Flutter 桌面构建依赖（文件位置 `.github/workflows/build.yml:48-51`）。
  - 命令：`sudo apt-get update && sudo apt-get install -y clang cmake ninja-build pkg-config libgtk-3-dev`
- 修正上传产物路径为 Flutter 输出的分发包目录（`.github/workflows/build.yml:67-68`）：
  - 由 `namepicker\build\linux\x64\runner\Release` 改为 `namepicker/build/linux/x64/release/bundle`。

**验证与影响**
- Linux 构建：`flutter build linux` 可正常生成并通过 `pkg-config` 解析 `gtk+-3.0`，CMake 不再报错。
- 产物上传：`actions/upload-artifact` 现会正确上传分发包目录，便于下载与发布。
- Windows 构建：未改动，保持现状与正常性。

**变更文件**
- `.github/workflows/build.yml`（Linux 依赖安装与产物路径修正）