### PR TITLE
ci: Update macOS runner versions for build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -89,7 +89,7 @@ jobs:
           path: |
             namepicker_*_amd64.deb
   build_macos_intel:
-    runs-on: macos-13
+    runs-on: macos-15-intel
     steps:
       - name: Clone repository
         uses: actions/checkout@v4
@@ -123,7 +123,7 @@ jobs:
             namepicker/build/macos/Build/Products/Release/*-macOS-x64.zip
 
   build_macos_arm:
-    runs-on: macos-14
+    runs-on: macos-15
     steps:
       - name: Clone repository
         uses: actions/checkout@v4


### PR DESCRIPTION
- Update Intel macOS runner from macos-13 to macos-15-intel
- Update ARM macOS runner from macos-14 to macos-15
- Ensure compatibility with latest macOS runner environments
- Improve build stability and access to newer build tools